### PR TITLE
Renamed instances of 'IBM-Blockchain-Starter-Kit' to 'Blockchain-Kit'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # IBM Blockchain Starter Kit Documentation
 
-The starter kit documentation is hosted using GitHub pages at [https://ibm-blockchain-starter-kit.github.io/](https://ibm-blockchain-starter-kit.github.io/) using the [Jekyll Doc Theme](https://github.com/tomjoht/documentation-theme-jekyll).
+The starter kit documentation is hosted using GitHub pages at [https://blockchain-kit.github.io/](https://blockchain-kit.github.io/) using the [Jekyll Doc Theme](https://github.com/tomjoht/documentation-theme-jekyll).
 
 All the documentation is written in [Markdown](https://daringfireball.net/projects/markdown/syntax) in files under the **pages** directory.
 
-To add a new page, you may also want to include it in a sidebar, which you can find under the **_data/sidebars** directory.
+To add a new page, you may also want to include it in a sidebar, which you can find under the **\_data/sidebars** directory.
 
 For more details, including how to build the documentation locally, read the Jekyll Doc Theme's [getting started guide](https://idratherbewriting.com/documentation-theme-jekyll/index.html).

--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
-repository: IBM-Blockchain-Starter-Kit/IBM-Blockchain-Starter-Kit.github.io
+repository: Blockchain-Kit/Blockchain-Kit.github.io
 
 output: web
 # this property is useful for conditional filtering of content that is separate from the PDF.
@@ -31,9 +31,9 @@ port: 4000
 # the port where the preview is rendered. You can leave this as is unless you have other Jekyll builds using this same port that might cause conflicts. in that case, use another port such as 4006.
 
 exclude:
-  - .gitignore
-  - LICENSE
-  - README.md
+    - .gitignore
+    - LICENSE
+    - README.md
 # these are the files and directories that jekyll will exclude from the build
 
 feedback_subject_line: Blockchain Starter Kit
@@ -55,33 +55,32 @@ highlighter: rouge
 
 markdown: kramdown
 kramdown:
- input: GFM
- auto_ids: true
- hard_wrap: false
- syntax_highlighter: rouge
+    input: GFM
+    auto_ids: true
+    hard_wrap: false
+    syntax_highlighter: rouge
 
 # filter used to process markdown. note that kramdown differs from github-flavored markdown in some subtle ways
 
 defaults:
-  -
-    scope:
-      path: ""
-      type: "pages"
-    values:
-      layout: "page"
-      comments: true
-      search: true
-      sidebar: home_sidebar
-      topnav: topnav
+    - scope:
+          path: ''
+          type: 'pages'
+      values:
+          layout: 'page'
+          comments: true
+          search: true
+          sidebar: home_sidebar
+          topnav: topnav
 
 # these are defaults used for the frontmatter for these file types
 
 sidebars:
-- home_sidebar
+    - home_sidebar
 
-description: "IBM Blockchain Starter Kit documentation."
+description: 'IBM Blockchain Starter Kit documentation.'
 # the description is used in the feed.xml file
 
 # needed for sitemap.xml file only
-url: https://ibm-blockchain-starter-kit.github.io/
+url: https://blockchain-kit.github.io/
 baseurl: /

--- a/_data/topnav.yml
+++ b/_data/topnav.yml
@@ -1,7 +1,7 @@
 ## Topnav single links
 ## if you want to list an external url, use external_url instead of url. the theme will apply a different link base.
 topnav:
-- title: Topnav
-  items:
-    - title: GitHub
-      external_url: https://github.com/IBM-Blockchain-Starter-Kit/IBM-Blockchain-Starter-Kit.github.io
+    - title: Topnav
+      items:
+          - title: GitHub
+            external_url: https://github.com/Blockchain-Kit/Blockchain-Kit.github.io

--- a/pages/bootstrap-projects.md
+++ b/pages/bootstrap-projects.md
@@ -1,5 +1,5 @@
 ---
-title: "Bootstrap Projects"
+title: 'Bootstrap Projects'
 keywords: bootstrap projects repo repository chaincode smart contract sample git github REST API
 sidebar: home_sidebar
 permalink: bootstrap-projects.html
@@ -13,13 +13,13 @@ There are several types of bootstrap projects:
 
 ## API
 
-There is currently one API repository, [api-bootstrap](https://github.com/IBM-Blockchain-Starter-Kit/api-bootstrap) which provides a bootstrap REST API server. The REST API server is built with express.js and includes a simple `/health` check endpoint. It includes a Swagger UI and uses the mocha framework for testing.
+There is currently one API repository, [api-bootstrap](https://github.com/Blockchain-Kit/api-bootstrap) which provides a bootstrap REST API server. The REST API server is built with express.js and includes a simple `/health` check endpoint. It includes a Swagger UI and uses the mocha framework for testing.
 
 ## Chaincode
 
 There are currently two chaincode repositories which provide bootstrap chaincode implementations in Go and Node.js respectively:
 
-- [chaincode-bootstrap](https://github.com/IBM-Blockchain-Starter-Kit/chaincode-bootstrap)
-- [nodejs-chaincode-bootstrap](https://github.com/IBM-Blockchain-Starter-Kit/nodejs-chaincode-bootstrap)
+-   [chaincode-bootstrap](https://github.com/Blockchain-Kit/chaincode-bootstrap)
+-   [nodejs-chaincode-bootstrap](https://github.com/Blockchain-Kit/nodejs-chaincode-bootstrap)
 
 {% include links.html %}

--- a/pages/build-scripts.md
+++ b/pages/build-scripts.md
@@ -1,51 +1,51 @@
 ---
-title: "Build Scripts"
+title: 'Build Scripts'
 keywords: build test deploy environment variables scripts bash shell
 sidebar: home_sidebar
 permalink: build-scripts.html
 ---
 
-There are a common library of build scripts in [the build-lib repository](https://github.com/IBM-Blockchain-Starter-Kit/build-lib). These build scripts have been developed to work with IBM Cloud DevOps Delivery Pipelines, however you may also be able to use them with other continuous integration tools.
+There are a common library of build scripts in [the build-lib repository](https://github.com/Blockchain-Kit/build-lib). These build scripts have been developed to work with IBM Cloud DevOps Delivery Pipelines, however you may also be able to use them with other continuous integration tools.
 
 ## Using a specific version
 
-In most cases you should use a specific version of the build scripts to avoid problems when breaking changes are made to the scripts. If you use a toolchain template, this should have already been configured for you in the *PREPARE* build stage, however you may wish to update the version to pick up any fixes.
+In most cases you should use a specific version of the build scripts to avoid problems when breaking changes are made to the scripts. If you use a toolchain template, this should have already been configured for you in the _PREPARE_ build stage, however you may wish to update the version to pick up any fixes.
 
-To fetch the latest released versions of the blockchain build scripts, use the contents of the [prepare.sh](https://github.com/IBM-Blockchain-Starter-Kit/build-lib/blob/master/src/prepare.sh) script in the *PREPARE* pipeline build job.
+To fetch the latest released versions of the blockchain build scripts, use the contents of the [prepare.sh](https://github.com/Blockchain-Kit/build-lib/blob/master/src/prepare.sh) script in the _PREPARE_ pipeline build job.
 
-The *SCRIPT_DIR* variable should be configured to specify where the build scripts should be extracted to, which should be set on the build stage containing the prepare script. For example, `./scripts/`.
+The _SCRIPT_DIR_ variable should be configured to specify where the build scripts should be extracted to, which should be set on the build stage containing the prepare script. For example, `./scripts/`.
 
-Similarly, the required build library version is configured using the *BUILD_LIB_URL* environment variable The *BUILD_LIB_URL* environment variable should be set to the location of a `blockchain-build-lib.tgz` file. For example,
+Similarly, the required build library version is configured using the _BUILD_LIB_URL_ environment variable The _BUILD_LIB_URL_ environment variable should be set to the location of a `blockchain-build-lib.tgz` file. For example,
 
 ```
-https://github.com/IBM-Blockchain-Starter-Kit/build-lib/releases/download/<release>/blockchain-build-lib.tgz
+https://github.com/Blockchain-Kit/build-lib/releases/download/<release>/blockchain-build-lib.tgz
 ```
 
-where *release* is the required release from the list of [available releases](https://github.com/IBM-Blockchain-Starter-Kit/build-lib/releases).
+where _release_ is the required release from the list of [available releases](https://github.com/Blockchain-Kit/build-lib/releases).
 
 ## Using the latest unstable version
 
-This is only likely to be useful if you are contributing changes to the build script library. To fetch the latest unstable versions of the blockchain build scripts, use the following code in the *PREPARE* build stage:
+This is only likely to be useful if you are contributing changes to the build script library. To fetch the latest unstable versions of the blockchain build scripts, use the following code in the _PREPARE_ build stage:
 
 ```
 source <(curl -sSL "${SCRIPT_URL}/prepare-unstable.sh")
 ```
 
-The *SCRIPT_DIR* variable should be configured to specify where the build scripts should be copied to, which should be set on the build stage containing the prepare script. For eaxmple, `./scripts/`.
+The _SCRIPT_DIR_ variable should be configured to specify where the build scripts should be copied to, which should be set on the build stage containing the prepare script. For eaxmple, `./scripts/`.
 
-Similarly, the *SCRIPT_URL* environment variable should be set to the source location of the scripts you want to use. For example,
+Similarly, the _SCRIPT_URL_ environment variable should be set to the source location of the scripts you want to use. For example,
 
 ```
 https://raw.githubusercontent.com/<github_user>/build-lib/master/src
 ```
 
-where *github_user* would be `IBM-Blockchain-Starter-Kit` for the starter kit organisation, or your own GitHub user ID if you have forked the repository.
+where _github_user_ would be `Blockchain-Kit` for the starter kit organisation, or your own GitHub user ID if you have forked the repository.
 
 ## Using customised scripts
 
 In some cases you may wish to customise the build scripts to handle your own specific circumstances. In this case you can include modified copies of the build scripts in the source repository you are building.
 
-None of your own build scripts that exist in the *SCRIPT_DIR* directory in your source code repository will be overwritten when scripts are fetched in the prepare script, so you can override some or all of the build script library as required. Check the environment variable settings on each build stage to find the value of the *SCRIPT_DIR* variable.
+None of your own build scripts that exist in the _SCRIPT_DIR_ directory in your source code repository will be overwritten when scripts are fetched in the prepare script, so you can override some or all of the build script library as required. Check the environment variable settings on each build stage to find the value of the _SCRIPT_DIR_ variable.
 
 ## Calling the build scripts
 
@@ -56,23 +56,23 @@ If you are not using one of the starter kit toolchain templates, you need to add
 source "${SCRIPT_DIR}/router.sh" <stage> <platform>
 ```
 
-where *stage* is the build stage (`build`, `test` or `deploy`) and *platform* is one of the supported platforms, described below.
+where _stage_ is the build stage (`build`, `test` or `deploy`) and _platform_ is one of the supported platforms, described below.
 
-The *SCRIPT_DIR* variable should be configured in the build stage enviornment variables, and should match the same variable in the *PREPARE* stage where the scripts are downloaded.
+The _SCRIPT_DIR_ variable should be configured in the build stage enviornment variables, and should match the same variable in the _PREPARE_ stage where the scripts are downloaded.
 
-The router script will use the *stage* and *platform* arguments to run the appropriate scripts.
+The router script will use the _stage_ and _platform_ arguments to run the appropriate scripts.
 
 ### go-chaincode
 
 Use the `go-chaincode` platform to build Go chaincode.
 
-If you are starting a new chaincode project using the Go language, you can clone and modify the [chaincode-bootstrap](https://github.com/IBM-Blockchain-Starter-Kit/chaincode-bootstrap) project. Alternatively, you can generate a new Go chaincode project using the [Yeoman generator for Hyperledger Fabric](https://www.npmjs.com/package/generator-fabric).
+If you are starting a new chaincode project using the Go language, you can clone and modify the [chaincode-bootstrap](https://github.com/Blockchain-Kit/chaincode-bootstrap) project. Alternatively, you can generate a new Go chaincode project using the [Yeoman generator for Hyperledger Fabric](https://www.npmjs.com/package/generator-fabric).
 
 ### js-chaincode
 
 Use the `js-chaincode` platform to build Node.js or TypeScript chaincode.
 
-If you are starting a new chaincode project using Node.js, you can clone and modify the [nodejs-chaincode-bootstrap](https://github.com/IBM-Blockchain-Starter-Kit/nodejs-chaincode-bootstrap) project. Alternatively, you can generate a new Node.js or TypeScript chaincode project using the [Yeoman generator for Hyperledger Fabric](https://www.npmjs.com/package/generator-fabric).
+If you are starting a new chaincode project using Node.js, you can clone and modify the [nodejs-chaincode-bootstrap](https://github.com/Blockchain-Kit/nodejs-chaincode-bootstrap) project. Alternatively, you can generate a new Node.js or TypeScript chaincode project using the [Yeoman generator for Hyperledger Fabric](https://www.npmjs.com/package/generator-fabric).
 
 ## Debugging scripts
 

--- a/pages/community.md
+++ b/pages/community.md
@@ -13,7 +13,7 @@ We’re extremely interested in your feedback about how we could make starter ki
 
 {% include warning.html content="this is a **prototype** that is currently under development by the IBM Blockchain team. As a result, it may dramatically change, have major bugs, completely fail to work, or disappear altogether. There is **no** officially provided support for this project; any bugs that you report may go unfixed for a longer period of time than you're comfortable with. If you're happy with all of that, then please carry on reading!" %}
 
-If you encounter any problems, it's worth checking whether there is already an issue open. We track track issues across all the starter kit repositories using [ZenHub](https://app.zenhub.com/workspace/o/blockchain-kitblockchain-kit.github.io/boards?repos=137356912,137370280,137372062,137372247,137376058,137474815,143315611). If there is not already an issue open, please create one and include as much detail as possible to help us track down the problem.
+If you encounter any problems, it's worth checking whether there is already an issue open. We track track issues across all the starter kit repositories using [ZenHub](https://app.zenhub.com/workspace/o/ibm-blockchain-starter-kit/ibm-blockchain-starter-kit.github.io/boards?repos=137356912,137370280,137372062,137372247,137376058,137474815,143315611). If there is not already an issue open, please create one and include as much detail as possible to help us track down the problem.
 
 ## Contributing
 

--- a/pages/community.md
+++ b/pages/community.md
@@ -1,5 +1,5 @@
 ---
-title: "Community"
+title: 'Community'
 keywords: community chat help Gitter wiki GitHub issues ZenHub feedback contributing
 sidebar: home_sidebar
 permalink: community.html
@@ -7,19 +7,19 @@ permalink: community.html
 
 ## Feedback and Questions
 
-We’re extremely interested in your feedback about how we could make starter kit even better, so please do get in touch via [our Gitter room](https://gitter.im/IBM-Blockchain-Starter-Kit/Lobby?utm_source=share-link&utm_medium=link&utm_campaign=share-link).
+We’re extremely interested in your feedback about how we could make starter kit even better, so please do get in touch via [our Gitter room](https://gitter.im/Blockchain-Kit/Lobby?utm_source=share-link&utm_medium=link&utm_campaign=share-link).
 
 ## Issues
 
 {% include warning.html content="this is a **prototype** that is currently under development by the IBM Blockchain team. As a result, it may dramatically change, have major bugs, completely fail to work, or disappear altogether. There is **no** officially provided support for this project; any bugs that you report may go unfixed for a longer period of time than you're comfortable with. If you're happy with all of that, then please carry on reading!" %}
 
-If you encounter any problems, it's worth checking whether there is already an issue open. We track track issues across all the starter kit repositories using [ZenHub](https://app.zenhub.com/workspace/o/ibm-blockchain-starter-kit/ibm-blockchain-starter-kit.github.io/boards?repos=137356912,137370280,137372062,137372247,137376058,137474815,143315611). If there is not already an issue open, please create one and include as much detail as possible to help us track down the problem.
+If you encounter any problems, it's worth checking whether there is already an issue open. We track track issues across all the starter kit repositories using [ZenHub](https://app.zenhub.com/workspace/o/blockchain-kitblockchain-kit.github.io/boards?repos=137356912,137370280,137372062,137372247,137376058,137474815,143315611). If there is not already an issue open, please create one and include as much detail as possible to help us track down the problem.
 
 ## Contributing
 
-{% include callout.html content="We welcome contributions!" type="primary" %} 
+{% include callout.html content="We welcome contributions!" type="primary" %}
 
-There should be a contributing guide in each of the repositories in [our GitHub organisation](https://github.com/IBM-Blockchain-Starter-Kit), for example the [build-lib contributing guide](https://github.com/IBM-Blockchain-Starter-Kit/build-lib/blob/master/CONTRIBUTING.md).
+There should be a contributing guide in each of the repositories in [our GitHub organisation](https://github.com/Blockchain-Kit), for example the [build-lib contributing guide](https://github.com/Blockchain-Kit/build-lib/blob/master/CONTRIBUTING.md).
 
 If you have any questions, especially if you're about to start on a large piece of work, please get in touch.
 

--- a/pages/index.md
+++ b/pages/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Introduction"
+title: 'Introduction'
 keywords: about homepage
 sidebar: home_sidebar
 permalink: index.html
@@ -17,9 +17,9 @@ A typical permissionable blockchain application stack has 3 highly coupled layer
 
 There are several [tools](#tools) within this kit which will allow a developer to implement, deploy, and link each layer of this stack.
 
-There are also some [sample applications](#samples) which can demonstrate typical implementations and showcase common patterns. 
+There are also some [sample applications](#samples) which can demonstrate typical implementations and showcase common patterns.
 
-If you would like to contribute to the kit, check out our [contributing guide](https://github.com/IBM-Blockchain-Starter-Kit/IBM-Blockchain-Starter-Kit.github.io/wiki/Contributing-to-Blockchain-Starter-Kit).
+If you would like to contribute to the kit, check out our [contributing guide](https://github.com/Blockchain-Kit/Blockchain-Kit.github.io/wiki/Contributing-to-Blockchain-Starter-Kit).
 
 # Tools
 
@@ -31,24 +31,27 @@ Check out the [toolchains](toolchains.html).
 
 ## Scaffolding Code
 
-We have created several repositories which can serve as the foundational structure and default configuration for each layer of the stack. 
+We have created several repositories which can serve as the foundational structure and default configuration for each layer of the stack.
 
 ### Smart Contract Scaffolding
-[Fabric: NodeJS](https://github.com/IBM-Blockchain-Starter-Kit/nodejs-chaincode-bootstrap)  
-[Fabric: goLang](https://github.com/IBM-Blockchain-Starter-Kit/chaincode-bootstrap)  
-[Composer: JS/bna](https://github.com/IBM-Blockchain-Starter-Kit/chaincode-bootstrap)  
- 
+
+[Fabric: NodeJS](https://github.com/Blockchain-Kit/nodejs-chaincode-bootstrap)  
+[Fabric: goLang](https://github.com/Blockchain-Kit/chaincode-bootstrap)  
+[Composer: JS/bna](https://github.com/Blockchain-Kit/chaincode-bootstrap)
+
 ### API Scaffolding
-[Fabric: Express](https://github.com/IBM-Blockchain-Starter-Kit/api-bootstrap)   
+
+[Fabric: Express](https://github.com/Blockchain-Kit/api-bootstrap)
 
 ### UI Scaffolding (WIP)
-*Coming Soon...*
+
+_Coming Soon..._
 
 ## Build Test Deploy Framework (WIP)
 
-We have built a comprehensive build-test-deploy framework for developing smart contracts within Hyperledger frameworks. This framework is used within the delivery pipelines created by the bluemix toolchains in this kit.  We are planning on releasing a contained CLI which employs these scripts soon!
+We have built a comprehensive build-test-deploy framework for developing smart contracts within Hyperledger frameworks. This framework is used within the delivery pipelines created by the bluemix toolchains in this kit. We are planning on releasing a contained CLI which employs these scripts soon!
 
-Check out the [scripting library](https://github.com/IBM-Blockchain-Starter-Kit/build-lib).
+Check out the [scripting library](https://github.com/Blockchain-Kit/build-lib).
 
 # Samples
 

--- a/pages/toolchain-templates.md
+++ b/pages/toolchain-templates.md
@@ -1,5 +1,5 @@
 ---
-title: "Toolchain Templates"
+title: 'Toolchain Templates'
 keywords: toolchain templates delivery pipeline devops build test deploy environment variables IBM Cloud
 sidebar: home_sidebar
 permalink: toolchain-templates.html
@@ -7,38 +7,37 @@ permalink: toolchain-templates.html
 
 The starter kit provides several [Toolchain Templates](https://github.com/open-toolchain/sdk/wiki/Toolchain-Templates) which can be used to create IBM DevOps [Toolchains](https://console.bluemix.net/docs/services/ContinuousDelivery/toolchains_about.html#toolchains_about) with the appropriate tools pre-configured to build and deploy IBM Blockchain Platform projects.
 
-Each toolchain template has its own branch in the [blockchain-toolchain](https://github.com/IBM-Blockchain-Starter-Kit/blockchain-toolchain) repository. The toolchain creation page for each template will typically be opened using a button or link provided as part of an article or tutorial. The URL parameters for these are described on the [Toolchain Creation Page Parameters](https://github.com/open-toolchain/sdk/wiki/Toolchain-Creation-Page-Parameters) Wiki page.
+Each toolchain template has its own branch in the [blockchain-toolchain](https://github.com/Blockchain-Kit/blockchain-toolchain) repository. The toolchain creation page for each template will typically be opened using a button or link provided as part of an article or tutorial. The URL parameters for these are described on the [Toolchain Creation Page Parameters](https://github.com/open-toolchain/sdk/wiki/Toolchain-Creation-Page-Parameters) Wiki page.
 
 ## Smart Contract Toolchain
 
-{% include callout.html content="Branch: <a href='https://github.com/IBM-Blockchain-Starter-Kit/blockchain-toolchain/tree/chaincode'>chaincode</a>" type="primary" %} 
+{% include callout.html content="Branch: <a href='https://github.com/Blockchain-Kit/blockchain-toolchain/tree/chaincode'>chaincode</a>" type="primary" %}
 
 The smart contract toolchain can build smart contracts written in Go or Node.js, and deploy deploy them to the IBM Blockchain Platform.
 
 Additional query parameters used by this toolchain:
 
-Query parameter | Description | Valid values
----- | ---- | ----
-`platform` | The type of project to build | `go` or `js`
-`bootstrapRepo` | The source repository of the project to build | Repository URL
+| Query parameter | Description                                   | Valid values   |
+| --------------- | --------------------------------------------- | -------------- |
+| `platform`      | The type of project to build                  | `go` or `js`   |
+| `bootstrapRepo` | The source repository of the project to build | Repository URL |
 
 For example:
 
 ### Go chaincode
 
 ```
-https://console.ng.bluemix.net/devops/setup/deploy/?repository=https://github.com/IBM-Blockchain-Starter-Kit/blockchain-toolchain&branch=chaincode&platform=go&bootstrapRepo=https://github.com/IBM-Blockchain-Starter-Kit/chaincode-bootstrap.git
+https://console.ng.bluemix.net/devops/setup/deploy/?repository=https://github.com/Blockchain-Kit/blockchain-toolchain&branch=chaincode&platform=go&bootstrapRepo=https://github.com/Blockchain-Kit/chaincode-bootstrap.git
 ```
 
-[![Deploy To Bluemix](https://console.ng.bluemix.net/devops/graphics/create_toolchain_button.png)](https://console.ng.bluemix.net/devops/setup/deploy/?repository=https://github.com/IBM-Blockchain-Starter-Kit/blockchain-toolchain&branch=chaincode&platform=go&bootstrapRepo=https://github.com/IBM-Blockchain-Starter-Kit/chaincode-bootstrap.git)
+[![Deploy To Bluemix](https://console.ng.bluemix.net/devops/graphics/create_toolchain_button.png)](https://console.ng.bluemix.net/devops/setup/deploy/?repository=https://github.com/Blockchain-Kit/blockchain-toolchain&branch=chaincode&platform=go&bootstrapRepo=https://github.com/Blockchain-Kit/chaincode-bootstrap.git)
 
 ### Node.js chaincode
 
 ```
-https://console.ng.bluemix.net/devops/setup/deploy/?repository=https://github.com/IBM-Blockchain-Starter-Kit/blockchain-toolchain&branch=chaincode&platform=js&bootstrapRepo=https://github.com/IBM-Blockchain-Starter-Kit/nodejs-chaincode-bootstrap.git
+https://console.ng.bluemix.net/devops/setup/deploy/?repository=https://github.com/Blockchain-Kit/blockchain-toolchain&branch=chaincode&platform=js&bootstrapRepo=https://github.com/Blockchain-Kit/nodejs-chaincode-bootstrap.git
 ```
 
-[![Deploy To Bluemix](https://console.ng.bluemix.net/devops/graphics/create_toolchain_button.png)](https://console.ng.bluemix.net/devops/setup/deploy/?repository=https://github.com/IBM-Blockchain-Starter-Kit/blockchain-toolchain&branch=chaincode&platform=js&bootstrapRepo=https://github.com/IBM-Blockchain-Starter-Kit/nodejs-chaincode-bootstrap.git)
-
+[![Deploy To Bluemix](https://console.ng.bluemix.net/devops/graphics/create_toolchain_button.png)](https://console.ng.bluemix.net/devops/setup/deploy/?repository=https://github.com/Blockchain-Kit/blockchain-toolchain&branch=chaincode&platform=js&bootstrapRepo=https://github.com/Blockchain-Kit/nodejs-chaincode-bootstrap.git)
 
 {% include links.html %}

--- a/pages/toolchains.md
+++ b/pages/toolchains.md
@@ -5,17 +5,17 @@ sidebar: home_sidebar
 permalink: toolchains.html
 ---
 
-The toolchains contained in this repository will configure your development environment with version tracking (cloning from a scaffolding repo) and continuous integration (using our build-test-deploy framework) on the bluemix domain. 
+The toolchains contained in this repository will configure your development environment with version tracking (cloning from a scaffolding repo) and continuous integration (using our build-test-deploy framework) on the bluemix domain.
 
 ## Prerequisites
 
-You will need an [IBM Cloud account](https://console.bluemix.net/dashboard/apps/) with permissions to create new services on the bluemix domain. 
+You will need an [IBM Cloud account](https://console.bluemix.net/dashboard/apps/) with permissions to create new services on the bluemix domain.
 
-You will need a [IBM Blockchain platform](https://console.bluemix.net/docs/services/blockchain/index.html#ibm-blockchain-platform) payment plan associated with this account. A starter plan or enterprise plan will work. 
+You will need a [IBM Blockchain platform](https://console.bluemix.net/docs/services/blockchain/index.html#ibm-blockchain-platform) payment plan associated with this account. A starter plan or enterprise plan will work.
 
 ## How it works
 
-Upon clicking one of the [buttons](#choose-your-desired-platform) below, you will be redirected to a [bluemix toolchain](https://console.bluemix.net/docs/services/ContinuousDelivery/toolchains_about.html) creation page. In order for this to work properly, you should be logged into your bluemix account. On this page, you will be prompted with a toolchain creation form. 
+Upon clicking one of the [buttons](#choose-your-desired-platform) below, you will be redirected to a [bluemix toolchain](https://console.bluemix.net/docs/services/ContinuousDelivery/toolchains_about.html) creation page. In order for this to work properly, you should be logged into your bluemix account. On this page, you will be prompted with a toolchain creation form.
 
 ### Toolchain Setup
 
@@ -23,33 +23,32 @@ The top section of the form configures the name of the toolchain service, the re
 
 ![Toolchain Config Image](toolchain_config.png)
 
-The rest of the form will be specifically tailored to the layer of the stack you are working on, and what Hyperledger framework you have selected. More information is available on the following layer specific walkthroughs. 
+The rest of the form will be specifically tailored to the layer of the stack you are working on, and what Hyperledger framework you have selected. More information is available on the following layer specific walkthroughs.
 
-Smart Contract Toolchain Walkthrough: [here](https://github.com/IBM-Blockchain-Starter-Kit/blockchain-toolchain/blob/chaincode/README.md)
+Smart Contract Toolchain Walkthrough: [here](https://github.com/Blockchain-Kit/blockchain-toolchain/blob/chaincode/README.md)
 
-API Toolchain Walkthrough: [here](https://github.com/IBM-Blockchain-Starter-Kit/blockchain-toolchain/blob/api/README.md)
+API Toolchain Walkthrough: [here](https://github.com/Blockchain-Kit/blockchain-toolchain/blob/api/README.md)
 
-UI Toolchain Walkthrough: *coming soon...*
+UI Toolchain Walkthrough: _coming soon..._
 
 ## Choose a Framework and Layer
 
-One-Click Toolchain Creation|Layer|Framework|Language
----|---|---|---
-[![Deploy To Bluemix](https://console.ng.bluemix.net/devops/graphics/create_toolchain_button.png)](https://console.ng.bluemix.net/devops/setup/deploy/?repository=https://github.com/IBM-Blockchain-Starter-Kit/blockchain-toolchain&branch=chaincode&platform=go&bootstrapRepo=https://github.com/IBM-Blockchain-Starter-Kit/chaincode-bootstrap.git)| Smart Contract | Fabric | GoLang
-[![Deploy To Bluemix](https://console.ng.bluemix.net/devops/graphics/create_toolchain_button.png)](https://console.ng.bluemix.net/devops/setup/deploy/?repository=https://github.com/IBM-Blockchain-Starter-Kit/blockchain-toolchain&branch=chaincode&platform=js&bootstrapRepo=https://github.com/IBM-Blockchain-Starter-Kit/nodejs-chaincode-bootstrap.git)| Smart Contract | Fabric | NodeJS
-*Coming Soon...* | API | Fabric | Express
+| One-Click Toolchain Creation                                                                                                                                                                                                                                                                                                          | Layer          | Framework | Language |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- | --------- | -------- |
+| [![Deploy To Bluemix](https://console.ng.bluemix.net/devops/graphics/create_toolchain_button.png)](https://console.ng.bluemix.net/devops/setup/deploy/?repository=https://github.com/Blockchain-Kit/blockchain-toolchain&branch=chaincode&platform=go&bootstrapRepo=https://github.com/Blockchain-Kit/chaincode-bootstrap.git)        | Smart Contract | Fabric    | GoLang   |
+| [![Deploy To Bluemix](https://console.ng.bluemix.net/devops/graphics/create_toolchain_button.png)](https://console.ng.bluemix.net/devops/setup/deploy/?repository=https://github.com/Blockchain-Kit/blockchain-toolchain&branch=chaincode&platform=js&bootstrapRepo=https://github.com/Blockchain-Kit/nodejs-chaincode-bootstrap.git) | Smart Contract | Fabric    | NodeJS   |
+| _Coming Soon..._                                                                                                                                                                                                                                                                                                                      | API            | Fabric    | Express  |
 
-
-You can also create a toolchain using the following API to inject an existing repository as the input for the delivery pipeline. 
+You can also create a toolchain using the following API to inject an existing repository as the input for the delivery pipeline.
 
 ```
 https://console.ng.bluemix.net/devops/setup/deploy/
-?repository=https://github.com/IBM-Blockchain-Starter-Kit/blockchain-toolchain
+?repository=https://github.com/Blockchain-Kit/blockchain-toolchain
 &branch=chaincode
 &platform=<your_platform>
 &bootstrapRepo=<your_source_repo_url_here>
 ```
 
-This is only currently available for the chaincode layer. Valid platforms are 'go', 'composer', and 'js'. 
+This is only currently available for the chaincode layer. Valid platforms are 'go', 'composer', and 'js'.
 
 {% include links.html %}

--- a/pages/tutorials/blockchain-sample/sample-tutorial.md
+++ b/pages/tutorials/blockchain-sample/sample-tutorial.md
@@ -3,7 +3,7 @@ title: Blockchain Sample Tutorial
 keywords: sample tutorial composer
 sidebar: home_sidebar
 permalink: sample-tutorial.html
-summary: "These instructions include everything you need for developing smart contracts, exposing them via RESTful APIs, building end user applications, and automatically deploying everything to the IBM Cloud, including any future changes you make.<br /><br />Follow the steps below to get started:"
+summary: 'These instructions include everything you need for developing smart contracts, exposing them via RESTful APIs, building end user applications, and automatically deploying everything to the IBM Cloud, including any future changes you make.<br /><br />Follow the steps below to get started:'
 ---
 
 ## 1. Setting up the local development environment
@@ -36,13 +36,13 @@ In particular, we recommend that you follow the Hyperledger Composer development
 
 ## 2. Setting up the project and DevOps toolchain
 
-To start building a blockchain sample, you will first set up a DevOps toolchain that will automatically build, test, and deploy your blockchain application to the IBM Cloud.  The IBM Cloud DevOps service is used to run the DevOps toolchain, and a toolchain template that is suitable for developing samples is provided.
+To start building a blockchain sample, you will first set up a DevOps toolchain that will automatically build, test, and deploy your blockchain application to the IBM Cloud. The IBM Cloud DevOps service is used to run the DevOps toolchain, and a toolchain template that is suitable for developing samples is provided.
 
-During the toolchain setup, this GitHub repository will be cloned to a repository of your choosing.  You develop your blockchain application by working on your cloned GitHub repository. You do not need to manually clone this GitHub repository if you follow the steps below: please carry on reading!
+During the toolchain setup, this GitHub repository will be cloned to a repository of your choosing. You develop your blockchain application by working on your cloned GitHub repository. You do not need to manually clone this GitHub repository if you follow the steps below: please carry on reading!
 
 Click the following link to set up a DevOps toolchain for your blockchain application:
 
-[Set up DevOps toolchain](https://console.bluemix.net/devops/setup/deploy/?repository=https%3A//github.com/IBM-Blockchain-Starter-Kit/blockchain-toolchain&branch=sample-template&env_id=ibm%3Ayp%3Aus-south&deploy-region=ibm%3Ayp%3Aus-south&sampleRepo=https%3A//github.com/IBM-Blockchain-Starter-Kit/blockchain-sample-bootstrap)
+[Set up DevOps toolchain](https://console.bluemix.net/devops/setup/deploy/?repository=https%3A//github.com/Blockchain-Kit/blockchain-toolchain&branch=sample-template&env_id=ibm%3Ayp%3Aus-south&deploy-region=ibm%3Ayp%3Aus-south&sampleRepo=https%3A//github.com/Blockchain-Kit/blockchain-sample-bootstrap)
 
 The "Create a Toolchain" page will appear:
 
@@ -195,14 +195,13 @@ In this example, I have created an application called "marbles":
 The contents of the `manifest.yml` file at the bottom of the editor tell Cloud Foundry the command for running this application, the number of instances of the application to start, and the amount of memory each instance is given. For example:
 
 ```yaml
----
 applications:
-- disk_quota: 1024M
-  name: marbles
-  command: "node app.js"
-  path: "."
-  instances: 1
-  memory: 256M
+    - disk_quota: 1024M
+      name: marbles
+      command: 'node app.js'
+      path: '.'
+      instances: 1
+      memory: 256M
 ```
 
 See the Cloud Foundry and IBM Cloud documentation for further information on this file.
@@ -233,10 +232,7 @@ All applications deployed by this starter kit will be automatically bound to the
             "provider": null,
             "plan": "ibm-blockchain-plan-v1-starter-prod",
             "name": "blockchain-simons-blockchain-app",
-            "tags": [
-                "blockchain",
-                "ibm_created"
-            ]
+            "tags": ["blockchain", "ibm_created"]
         }
     ]
 }
@@ -298,10 +294,7 @@ Finally, all applications deployed by this starter kit will be automatically bou
             "provider": null,
             "plan": "ibm-blockchain-plan-v1-starter-prod",
             "name": "blockchain-simons-blockchain-app",
-            "tags": [
-                "blockchain",
-                "ibm_created"
-            ]
+            "tags": ["blockchain", "ibm_created"]
         }
     ]
 }

--- a/pages/tutorials/chaincode/chaincode-tutorial.md
+++ b/pages/tutorials/chaincode/chaincode-tutorial.md
@@ -3,7 +3,7 @@ title: Smart Contract Tutorial
 keywords: chaincode tutorial nodejs golang
 sidebar: home_sidebar
 permalink: chaincode-tutorial.html
-summary: "These instructions include everything you need for developing Hyperledger Fabric smart contracts.<br /><br />Follow the steps below to get started:"
+summary: 'These instructions include everything you need for developing Hyperledger Fabric smart contracts.<br /><br />Follow the steps below to get started:'
 ---
 
 ## Before you start
@@ -12,7 +12,7 @@ In order to follow this tutorial, you will need to know how to develop Hyperledg
 
 Hyperledger Fabric is a platform for building blockchain applications. Hyperledger Fabric provides the blockchain technology itself, along with APIs and SDKs that allow you to develop smart contracts and end user applications.
 
-You can learn more about Hyperledger Fabric, including how to set up your local development environment, by following the [Hyperledger Fabric tutorials](http://hyperledger-fabric.readthedocs.io/en/release-1.1/tutorials.html). 
+You can learn more about Hyperledger Fabric, including how to set up your local development environment, by following the [Hyperledger Fabric tutorials](http://hyperledger-fabric.readthedocs.io/en/release-1.1/tutorials.html).
 
 In particular, we recommend that you follow the Hyperledger Fabric "Writing Your First Application" and "Chaincode for Developers" tutorials. These tutorials will teach you how to develop a smart contract, and build an end user application.
 
@@ -24,9 +24,9 @@ To start building a new smart contract, you will first set up a DevOps toolchain
 
 Choose one of the following options to set up a DevOps toolchain for your new smart contract:
 
-- [Create Go smart contract toolchain](https://console.ng.bluemix.net/devops/setup/deploy/?repository=https://github.com/IBM-Blockchain-Starter-Kit/blockchain-toolchain&branch=chaincode&platform=go&bootstrapRepo=https://github.com/IBM-Blockchain-Starter-Kit/chaincode-bootstrap.git)
+-   [Create Go smart contract toolchain](https://console.ng.bluemix.net/devops/setup/deploy/?repository=https://github.com/Blockchain-Kit/blockchain-toolchain&branch=chaincode&platform=go&bootstrapRepo=https://github.com/Blockchain-Kit/chaincode-bootstrap.git)
 
-- [Create Node.js smart contract toolchain](https://console.ng.bluemix.net/devops/setup/deploy/?repository=https://github.com/IBM-Blockchain-Starter-Kit/blockchain-toolchain&branch=chaincode&platform=js&bootstrapRepo=https://github.com/IBM-Blockchain-Starter-Kit/nodejs-chaincode-bootstrap.git)
+-   [Create Node.js smart contract toolchain](https://console.ng.bluemix.net/devops/setup/deploy/?repository=https://github.com/Blockchain-Kit/blockchain-toolchain&branch=chaincode&platform=js&bootstrapRepo=https://github.com/Blockchain-Kit/nodejs-chaincode-bootstrap.git)
 
 The "Create a Toolchain" page will appear:
 
@@ -38,9 +38,9 @@ The second section of the form is a git repo and issue tracker configuration. De
 
 ![Version and Issue Tracking Config Image](./git_repo_issues_config.png)
 
-The third section of the form is a delivery pipeline configuration. Here you can target existing service instances by specifying their identifiers or provide unregistered identifier(s) to create new instance(s). 
+The third section of the form is a delivery pipeline configuration. Here you can target existing service instances by specifying their identifiers or provide unregistered identifier(s) to create new instance(s).
 
-This delivery pipeline will queue a build stage when new changes are pushed to the chaincode repository. A successful build stage in turn will queue the unit test stage. These tests should be defined in the git repository, where examples will be provided. A successful test stage will queue the deploy stage. The deploy configuration should be defined in the git repository, where examples will be provided. The deploy stage will target the services specified in the delivery pipeline form. 
+This delivery pipeline will queue a build stage when new changes are pushed to the chaincode repository. A successful build stage in turn will queue the unit test stage. These tests should be defined in the git repository, where examples will be provided. A successful test stage will queue the deploy stage. The deploy configuration should be defined in the git repository, where examples will be provided. The deploy stage will target the services specified in the delivery pipeline form.
 
 ![Pipeline Config Image](./pipeline_config.png)
 


### PR DESCRIPTION
Case sensitivity has been kept e.g. lower case versions will be lower case and upper case will be upper case and so on. Titles remain IBM Blockchain Starter Kit as they can be re-written when docs are addressed.